### PR TITLE
feat: move package to capgo scope

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,8 @@
-name: Build source code and send to Capgo
+name: Build and publish
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   push:
@@ -7,11 +11,18 @@ on:
 
 jobs:
   deploy:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
-    name: Build code and release
+    name: Build and publish to npm
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Check out
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          filter: blob:none
       - uses: oven-sh/setup-bun@v2
       - name: Install dependencies
         id: install_code
@@ -22,6 +33,18 @@ jobs:
       - name: Build
         id: build_code
         run: bun run build
-      - uses: JS-DevTools/npm-publish@v4
+      - name: Setup Node.js for npm publish
+        uses: actions/setup-node@v6
         with:
-          token: ${{ secrets.NPM_TOKEN }}
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+      - name: Publish to npm
+        if: ${{ !contains(github.ref, '-alpha.') }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
+      - name: Publish to npm with next tag
+        if: ${{ contains(github.ref, '-alpha.') }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --tag next --provenance --access public

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -8,25 +8,30 @@ on:
 
 jobs:
   bump-version:
-    if: '!startsWith(github.event.head_commit.message, ''chore(release):'')'
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
     runs-on: ubuntu-latest
     name: Bump version and create changelog with standard version
     steps:
       - name: Check out
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          filter: blob:none
           token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        id: install_code
+        run: bun i
       - name: Git config
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
       - name: Create bump and changelog main
         if: github.ref == 'refs/heads/main'
-        run: npx standard-version
+        run: bun run version:bump
       - name: Create bump and changelog development
         if: github.ref != 'refs/heads/main'
-        run: npx standard-version --prerelease alpha
+        run: bun run version:bump:alpha
       - name: Push to origin
         run: |
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ All config from .versionrc, .versionrc.json or .versionrc.js are supported
 
 ## Install
 
-`npm i capacitor-plugin-standard-version`
+`bun add -D @capgo/capacitor-plugin-standard-version`
 
 ## Usage
 
-Run `npx capacitor-plugin-standard-version` for update main version or `npx capacitor-plugin-standard-version --prerelease alpha` for alpha release for dev branch.
+Run `bunx capacitor-plugin-standard-version` for update main version or `bunx capacitor-plugin-standard-version --prerelease alpha` for alpha release for dev branch.
 
 This package will automatically manage your changelog and the version number in 4 places:
 - package.json (version key)
@@ -63,20 +63,23 @@ jobs:
     name: Bump version and create changelog with standard version
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun i
       - name: Git config
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
       - name: Create bump and changelog
         if: github.ref == 'refs/heads/main'
-        run: npx capacitor-plugin-standard-version
+        run: bunx capacitor-plugin-standard-version
       - name: Create bump and changelog
         if: github.ref != 'refs/heads/main'
-        run: npx capacitor-plugin-standard-version --prerelease alpha
+        run: bunx capacitor-plugin-standard-version --prerelease alpha
       - name: Push to origin
         run: |
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "capacitor-plugin-standard-version",
+  "name": "@capgo/capacitor-plugin-standard-version",
   "version": "2.0.20",
   "description": "Default standard-version config for capacitor plugin",
   "author": "Martin Donadieu <martindonadieu@gmail.com>",
@@ -23,11 +23,13 @@
     "capacitor-plugin-standard-version": "dist/index.js"
   },
   "scripts": {
-    "dev": "set NODE_ENV=development&& npx webpack --config webpack.config.js",
+    "dev": "NODE_ENV=development bunx webpack --config webpack.config.js",
     "no-debug": "node dist/index.js",
-    "build": "set NODE_ENV=production&& npx webpack --config webpack.config.js",
+    "build": "NODE_ENV=production bunx webpack --config webpack.config.js",
     "pack": "pkg",
     "lint": "eslint . --fix",
+    "version:bump": "bunx commit-and-tag-version",
+    "version:bump:alpha": "bunx commit-and-tag-version --prerelease alpha",
     "prepare": "husky"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- move the npm package to the `@capgo` scope
- replace `JS-DevTools/npm-publish@v4` with the Capgo-style Node 24 direct publish flow
- switch bump/docs examples from `npx` to Bun-native commands

## Testing
- bun install
- bun run lint
- bun run build
- bun run version:bump -- --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package renamed to `@capgo/capacitor-plugin-standard-version` for scoped distribution.
  * Migrated build tooling from npm to Bun for improved performance.
  * Updated CI/CD workflows for enhanced reliability and security.

* **Documentation**
  * Updated installation and usage instructions to reflect Bun-based tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->